### PR TITLE
Use primitive values as primitives, not objects

### DIFF
--- a/nestedtypes.js
+++ b/nestedtypes.js
@@ -84,7 +84,8 @@
 
     exports.Model = function(){
         var ModelProto = Backbone.Model.prototype,
-            originalSet = ModelProto.set;
+            originalSet = ModelProto.set,
+            primitiveTypes = [String, Number, Boolean];
 
         function delegateEvents( name, oldValue, newValue ){
             oldValue && this.stopListening( oldValue );
@@ -175,8 +176,13 @@
                     if( Ctor.prototype.triggerWhenChanged ){ // for models and collections...
                         attrs[ name ] = typeCastBackbone.call( this, Ctor, name, value, options );
                     }
-                    else if( value != null && !( value instanceof Ctor ) ){ // use constructor to convert to default type
-                        attrs[ name ]  = new Ctor( value );
+                    else if( value != null ){
+                        if( primitiveTypes.indexOf( Ctor ) > -1 ){ // use primitive types as is
+                            attrs[ name ] = Ctor( value );
+                        }
+                        else if( !( value instanceof Ctor ) ){ // use constructor to convert to default type
+                            attrs[ name ]  = new Ctor( value );
+                        }
                     }
                 }
                 else if( Ctor !== null ){
@@ -230,8 +236,13 @@
 
                         return this;
                     }
-                    else if( value != null && !( value instanceof Ctor ) ){
-                        value = new Ctor( value );
+                    else if( value != null ){
+                        if( primitiveTypes.indexOf( Ctor ) > -1 ){ // use primitive types as is
+                            value = Ctor( value );
+                        }
+                        else if( !( value instanceof Ctor ) ){ // use constructor to convert to default type
+                            value  = new Ctor( value );
+                        }
                     }
                 }
                 else if( Ctor !== null ){

--- a/test.all.js
+++ b/test.all.js
@@ -84,8 +84,12 @@ define( function( require, exports, module ){
         });
 
         it( 'cast attribute values to defined types on assignment', function(){
+            var type;
+
             user.loginCount = "5";
             user.loginCount.should.be.number;
+            type = typeof user.loginCount;
+            type.should.eql( 'number' );
 
             user.loginCount = "djkjkj";
             user.loginCount.should.be.NaN;
@@ -98,6 +102,12 @@ define( function( require, exports, module ){
 
             user.name = 34;
             user.name.should.be.string;
+            user.name.should.be.eql( '34' );
+
+            user.name = 'Joe';
+            type = typeof user.name;
+            type.should.eql( 'string' );
+            user.name.should.be.eql( 'Joe' );
         });
 
         var comment, Comment = Base.Model.extend({
@@ -120,6 +130,9 @@ define( function( require, exports, module ){
 
             comment.created.should.eql( comment.author.created );
             comment.created.should.be.instanceof( Date );
+            comment.text.should.eql( 'bla-bla-bla' );
+            var type = typeof comment.text;
+            type.should.eql( 'string' );
             comment.author.created.should.be.instanceof( Date );
         });
 


### PR DESCRIPTION
Use primitive values as primitives (String, Number, Boolean), not objects of those types.

Previous to this commit, a simple string `'abc'` would be stored as a String object which when inspected has this structure `{ 0: 'a', 1: 'b', 2: 'c', length: 3 }`. This is due to the fact that primitive values are not instances of the respective objects:

``` javascript
'abc' instanceof String // = false
123 instanceof Number // = false
```
